### PR TITLE
Bugfix Modellinfo Laden Button

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -26,6 +26,9 @@ class MainWindow(QMainWindow):
         self.ui.metriken_text_laden_pushbutton.clicked.connect(
             lambda: self.load_image(self.ui.metriken_text_label)
         )
+        self.ui.modell_info_laden_pushbutton.clicked.connect(
+            lambda: self.load_image(self.ui.modell_und_parameter_inhalt_label)
+        )
         self.ui.punktewolke_laden_pushbutton.clicked.connect(
             lambda: self.load_image(self.ui.punktewolke_bild_label)
         )


### PR DESCRIPTION
Kurzer Bugfix für den Button "Modell Erläuterung auswählen..."